### PR TITLE
Fix git-add widget to view short format and relative path

### DIFF
--- a/autoload/widgets/fzf-git-add
+++ b/autoload/widgets/fzf-git-add
@@ -10,11 +10,8 @@ fi
 
 selector-init 'git add --'
 
-private base_path="`git rev-parse --show-cdup | sed 's%/%\\/%g'`"
-
-git status --porcelain | \
-  sed "s/^\(..\) /\1\t${base_path}/" | \
-  grep "^.[MD?]" | \
+git status --short | \
+  grep '^.[MD?]' | \
   selector-select -m
 
 selector-filter "awk '{print \$2}'"


### PR DESCRIPTION
## Why

https://github.com/ytet5uy4/fzf-widgets/issues/8
https://github.com/ytet5uy4/fzf-widgets/issues/9

## What

* Use git `--short` option, not `--porcelain`