### PR TITLE
`private` replaced to `local` for support zsh < 5.3

### DIFF
--- a/autoload/base/selector-check-command
+++ b/autoload/base/selector-check-command
@@ -2,7 +2,7 @@
 
 if ! type $1 >/dev/null 2>&1; then
   if [[ -n $TMUX ]]; then
-    private msg="selector-check-command: command not found: $1"
+    local msg="selector-check-command: command not found: $1"
     tmux split-window "less <<< \"$msg\""
   fi
   return 1

--- a/autoload/base/selector-exec
+++ b/autoload/base/selector-exec
@@ -1,4 +1,4 @@
 #!/bin/zsh
 
-IFS=$'\n' private cmd="`cat $FZF_WIDGETS_CACHE`"
+IFS=$'\n' local cmd="`cat $FZF_WIDGETS_CACHE`"
 [[ -n $cmd ]] && $=cmd

--- a/autoload/base/selector-init
+++ b/autoload/base/selector-init
@@ -2,7 +2,7 @@
 
 if ! type fzf >/dev/null 2>&1; then
   if [[ -n $TMUX ]]; then
-    private msg='selector-init: command not found: fzf'
+    local msg='selector-init: command not found: fzf'
     tmux split-window "less <<< \"$msg\""
   fi
   return 1

--- a/autoload/base/selector-insert
+++ b/autoload/base/selector-insert
@@ -1,6 +1,7 @@
 #!/bin/zsh
 
-IFS=$'\n' local -a items=(`cat $FZF_WIDGETS_CACHE`)
+local -a items
+IFS=$'\n' items=(`cat $FZF_WIDGETS_CACHE`)
 if [[ -n $items ]]; then
   for item in $items; do RBUFFER+="$item:q " done
   CURSOR=$#RBUFFER

--- a/autoload/base/selector-insert
+++ b/autoload/base/selector-insert
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-IFS=$'\n' private -a items=(`cat $FZF_WIDGETS_CACHE`)
+IFS=$'\n' local -a items=(`cat $FZF_WIDGETS_CACHE`)
 if [[ -n $items ]]; then
   for item in $items; do RBUFFER+="$item:q " done
   CURSOR=$#RBUFFER

--- a/autoload/base/selector-select
+++ b/autoload/base/selector-select
@@ -1,9 +1,9 @@
 #!/bin/zsh
 
 if [[ -z $TMUX ]]; then
-  private selector='fzf'
+  local selector='fzf'
 elif type tmux fzf-tmux >/dev/null 2>&1; then
-  private selector='fzf-tmux'
+  local selector='fzf-tmux'
 fi
 
 cat | $selector $@ >! $FZF_WIDGETS_CACHE
@@ -13,7 +13,7 @@ if [[ $? = 130 ]]; then
   return 1
 elif [[ -z `cat $FZF_WIDGETS_CACHE` ]]; then
   if [[ -n $TMUX ]]; then
-    private msg="selector-exec: there's no match"
+    local msg="selector-exec: there's no match"
     tmux split-window "less <<< \"$msg\""
   fi
   selector-clear

--- a/autoload/widgets/fzf-edit-dotfiles
+++ b/autoload/widgets/fzf-edit-dotfiles
@@ -2,7 +2,7 @@
 
 if [[ -z $DOT_BASE_DIR ]]; then
   if [[ -n $TMUX ]]; then
-    private msg='fzf-edit-dotfiles: Not set \$DOT_BASE_DIR'
+    local msg='fzf-edit-dotfiles: Not set \$DOT_BASE_DIR'
     tmux split-window "less <<< \"$msg\""
   fi
   return 1

--- a/autoload/widgets/fzf-git-add
+++ b/autoload/widgets/fzf-git-add
@@ -2,7 +2,7 @@
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if [[ -n $TMUX ]]; then
-    private msg='fzf-git-add: Not a git repository'
+    local msg='fzf-git-add: Not a git repository'
     tmux split-window "less <<< \"$msg\""
   fi
   return 1

--- a/autoload/widgets/fzf-git-checkout
+++ b/autoload/widgets/fzf-git-checkout
@@ -2,7 +2,7 @@
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if [[ -n $TMUX ]]; then
-    private msg='fzf-git-checkout: Not a git repository'
+    local msg='fzf-git-checkout: Not a git repository'
     tmux split-window "less <<< \"$msg\""
   fi
   return 1

--- a/init.zsh
+++ b/init.zsh
@@ -3,21 +3,21 @@ export FZF_WIDGETS_ROOT="$0:a:h"
 : "Create cache directory" && () {
   if [[ -n $XDG_CACHE_HOME ]]; then
     [[ ! -d $XDG_CACHE_HOME ]] && mkdir $XDG_CACHE_HOME
-    private dir="$XDG_CACHE_HOME/fzf-widgets"
+    local dir="$XDG_CACHE_HOME/fzf-widgets"
   else
-    private dir="/tmp/fzf-widgets"
+    local dir="/tmp/fzf-widgets"
   fi
   [[ ! -d $dir ]] && mkdir $dir
   export FZF_WIDGETS_CACHE="$dir/data.txt"
 }
 
 : "Autoload functions and Create widgets" && () {
-  private dir="$FZF_WIDGETS_ROOT/autoload"
+  local dir="$FZF_WIDGETS_ROOT/autoload"
   fpath=($dir/**/*(N-/) $fpath)
 
   autoload -Uz `ls -F $dir/**/* | grep -v /`
 
-  private w
+  local w
   for w in `ls $dir/widgets/`; do zle -N $w; done
 }
 


### PR DESCRIPTION
### Tested widgets:
- fzf-change-dir
- fzf-change-recent-dir
- fzf-edit-files
- fzf-git-add
- fzf-git-checkout
- fzf-select-widget

`private` vars scoped current function. `local` vars scoped current function and inner functions.

Demo:
``` bash
#!/bin/zsh

test_private() {
    private pb="func"
    test_private_inner
}

test_private_inner() {
    echo "private_inner: pb = $pb"
    private pb="func_inner"
}

echo "pa = $pa"
echo "pb = $pb"
test_private

###

test_local() {
    local lb="func"
    test_local_inner
}

test_local_inner() {
    echo "local_inner: lb = $lb"
    local lb="func_inner"
}

echo "la = $la"
echo "lb = $lb"
test_local
```

Output:
``` bash
pa = 
pb = 
private_inner: pb = 
la = 
lb = 
local_inner: lb = func
```

After replace `private` to `local` all tested widgets begin works on zsh 5.1.1 (Ubuntu 16.04). On older systems (zsh 5.0.2 on Ubuntu 14.04, zsh 4.3.10 on Debian 6) startup errors leaved, but widgets don't inserted results.

On zsh <= 5.0.2 was:
```
selector-insert:3: unknown file attribute
```

Fixed by extract variable definition to separate line.

Now all tested widgets except `fzf-git-checkout` (see #14) works for zsh 5.0.2 and most widgets works for 4.3.10.