### PR TITLE
fzf-history from official fzf keybindings for antigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ currently these widgets are available:
 * change-repository
 * edit-files
 * edit-dotfiles
+* exec-history
 * exec-ssh
 * git-add
 * git-checkout
@@ -53,6 +54,7 @@ if zplug check 'ytet5uy4/fzf-widgets'; then
   bindkey '^@g'  fzf-change-repository
   bindkey '^@f'  fzf-edit-files
   bindkey '^@.'  fzf-edit-dotfiles
+  bindkey '^r'   fzf-exec-history
   bindkey '^@s'  fzf-exec-ssh
   bindkey '^@ga' fzf-git-add
   bindkey '^@gb' fzf-git-checkout

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ currently these widgets are available:
 * change-repository
 * edit-files
 * edit-dotfiles
-* exec-history
+* insert-history
 * exec-ssh
 * git-add
 * git-checkout
@@ -54,7 +54,7 @@ if zplug check 'ytet5uy4/fzf-widgets'; then
   bindkey '^@g'  fzf-change-repository
   bindkey '^@f'  fzf-edit-files
   bindkey '^@.'  fzf-edit-dotfiles
-  bindkey '^r'   fzf-exec-history
+  bindkey '^r'   fzf-insert-history
   bindkey '^@s'  fzf-exec-ssh
   bindkey '^@ga' fzf-git-add
   bindkey '^@gb' fzf-git-checkout

--- a/autoload/widgets/fzf-history
+++ b/autoload/widgets/fzf-history
@@ -1,0 +1,13 @@
+#!/bin/zsh
+
+selector-init
+
+fc -l 1 | selector-select --tac --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query="$LBUFFER" +m
+
+items=(`cat $FZF_WIDGETS_CACHE`)
+if [[ -n $items ]]; then
+  num=$items[1]
+  if [ -n "$num" ]; then
+    zle vi-fetch-history -n $num
+  fi
+fi

--- a/autoload/widgets/fzf-insert-history
+++ b/autoload/widgets/fzf-insert-history
@@ -2,7 +2,7 @@
 
 selector-init
 
-fc -l 1 | selector-select --tac --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query="$LBUFFER" +m
+fc -l 1 | selector-select --tac --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_WIDGETS_OPTS[insert-history] --query="$LBUFFER" +m
 
 items=(`cat $FZF_WIDGETS_CACHE`)
 if [[ -n $items ]]; then

--- a/init.zsh
+++ b/init.zsh
@@ -1,4 +1,5 @@
 export FZF_WIDGETS_ROOT="$0:a:h"
+typeset -gA FZF_WIDGETS_OPTS
 
 : "Create cache directory" && () {
   if [[ -n $XDG_CACHE_HOME ]]; then


### PR DESCRIPTION
Related: #10, #13, junegunn/fzf#86

## Why:
- junegunn/fzf official plugin with full installation conflicts with zsh-autosuggestions
- official plugin can't work with antigen
- Treri/fzf-zsh wrapper resolved conflict, but don't work with antigen too
- able to install one zsh-fzf plugin for all widgets with official features

## Features from official:
- support of contextual search (`--query`)
- support of `$FZF_CTRL_R_OPTS`
- show history numbers
- correct paste multiline commands with zsh builin `vi-fetch-history`

Tested on zsh 4.3.10, 5.0.2, 5.3.1

Revert commit 5f84b73 with fixes of #10.