### PR TITLE
Support $FZF_WIDGETS_OPTS for all widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ currently these widgets are available:
 
 ## Installation
 
-You can use zplug to install fzf-widgets.
-Add the following to your `.zshrc`:
+You can use zplug to install fzf-widgets. Add the following to your `.zshrc`:
 
 ```zsh
 zplug 'ytet5uy4/fzf-widgets'
@@ -44,11 +43,12 @@ zplug 'ytet5uy4/fzf-widgets'
 
 ## Configuration
 
-You can map widgets to whatever key you like.
-Add the following to your `.zshrc`:
+You can map widgets to whatever key you like and specify options of `fzf` to
+each widgets with `$FZF_WIDGETS_OPTS`. Add the following to your `.zshrc`:
 
 ```zsh
 if zplug check 'ytet5uy4/fzf-widgets'; then
+  # Map widgets to key
   bindkey '^@'   fzf-select-widget
   bindkey '^@c'  fzf-change-dir
   bindkey '^\'   fzf-change-recent-dir
@@ -60,6 +60,9 @@ if zplug check 'ytet5uy4/fzf-widgets'; then
   bindkey '^@ga' fzf-git-add-files
   bindkey '^@gc' fzf-git-checkout-branch
   bindkey '^@gd' fzf-git-delete-branches
+
+  # Enable Exact-match by fzf-insert-history
+  FZF_WIDGETS_OPTS[insert-history]='--exact'
 fi
 ```
 

--- a/autoload/widgets/fzf-change-dir
+++ b/autoload/widgets/fzf-change-dir
@@ -4,6 +4,6 @@ selector-init 'cd --'
 
 find . -mindepth 1 -type d -o -type l | \
   sed 's|\./||g' | \
-  selector-select +m
+  selector-select $FZF_WIDGETS_OPTS[change-dir] +m
 
 selector-insert

--- a/autoload/widgets/fzf-change-recent-dir
+++ b/autoload/widgets/fzf-change-recent-dir
@@ -6,7 +6,7 @@ selector-init 'cd --'
 
 cdr -l | \
   sed 's/^[^ ][^ ]*  *//' | \
-  selector-select +m
+  selector-select $FZF_WIDGETS_OPTS[change-recent-dir] +m
 
 selector-filter "sed 's|~|$HOME|g'"
 

--- a/autoload/widgets/fzf-change-repository
+++ b/autoload/widgets/fzf-change-repository
@@ -7,7 +7,7 @@ selector-init 'cd --'
 ghq list -p | \
   sort | \
   sed "s|$HOME|~|g" | \
-  selector-select +m
+  selector-select $FZF_WIDGETS_OPTS[change-repository] +m
 
 selector-filter "sed 's|~|$HOME|g'"
 

--- a/autoload/widgets/fzf-edit-dotfiles
+++ b/autoload/widgets/fzf-edit-dotfiles
@@ -10,6 +10,7 @@ fi
 
 selector-init "$EDITOR --"
 
-find $DOT_BASE_DIR -type f -o -type l | selector-select -m
+find $DOT_BASE_DIR -type f -o -type l | \
+  selector-select $FZF_WIDGETS_OPTS[edit-dotfiles] -m
 
 selector-insert

--- a/autoload/widgets/fzf-edit-files
+++ b/autoload/widgets/fzf-edit-files
@@ -4,6 +4,6 @@ selector-init "$EDITOR --"
 
 find -L * -type f -print -o -type l -print -o \
   \( -path '*/\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune \
-  2> /dev/null | selector-select -m
+  2> /dev/null | selector-select $FZF_WIDGETS_OPTS[edit-files] -m
 
 selector-insert

--- a/autoload/widgets/fzf-exec-ssh
+++ b/autoload/widgets/fzf-exec-ssh
@@ -7,6 +7,6 @@ cat ~/.ssh/config /etc/ssh/ssh_config 2>/dev/null | \
   grep -v '*' | \
   awk '{if (length($2) > 0) {print $2}}' | \
   sort -u | \
-  selector-select +m
+  selector-select $FZF_WIDGETS_OPTS[exec-ssh] +m
 
 selector-insert

--- a/autoload/widgets/fzf-git-add-files
+++ b/autoload/widgets/fzf-git-add-files
@@ -12,7 +12,7 @@ selector-init 'git add --'
 
 git status --short | \
   grep '^.[MD?]' | \
-  selector-select -m
+  selector-select $FZF_WIDGETS_OPTS[git-add-files] -m
 
 selector-filter "awk '{print \$2}'"
 

--- a/autoload/widgets/fzf-git-checkout-branch
+++ b/autoload/widgets/fzf-git-checkout-branch
@@ -13,7 +13,7 @@ selector-init 'git checkout'
 git branch --list -v | \
   grep -v '^\*' | \
   sed 's/^  *//' | \
-  selector-select +m
+  selector-select $FZF_WIDGETS_OPTS[git-checkout-branch] +m
 
 selector-filter "awk '{print \$1}'"
 

--- a/autoload/widgets/fzf-git-delete-branches
+++ b/autoload/widgets/fzf-git-delete-branches
@@ -13,7 +13,7 @@ selector-init 'git branch -D'
 git branch --list -v | \
   grep -v '^\*' | \
   sed 's/^  *//' | \
-  selector-select -m
+  selector-select $FZF_WIDGETS_OPTS[git-delete-branches] -m
 
 selector-filter "awk '{print \$1}'"
 

--- a/autoload/widgets/fzf-select-widget
+++ b/autoload/widgets/fzf-select-widget
@@ -5,7 +5,7 @@ selector-init
 ls $FZF_WIDGETS_ROOT/autoload/widgets/ | \
   sed -e 's/fzf-//g' | \
   egrep -v '^select-widget$' | \
-  selector-select +m
+  selector-select $FZF_WIDGETS_OPTS[select-widget] +m
 
 selector-filter "sed 's/^/fzf-/'"
 


### PR DESCRIPTION
## Why

`$FZF_WIDGETS_OPTS` can be used only in `fzf-insert-history` but want to use in all widgets.

## What

* Add `$FZF_WIDGETS_OPT` to all widgets
* Add description of `$FZF_WIDGETS_OPT` to README