### PR TITLE
Separate private cache directories for each user

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -6,9 +6,9 @@ typeset -gA FZF_WIDGETS_OPTS
     [[ ! -d $XDG_CACHE_HOME ]] && mkdir $XDG_CACHE_HOME
     local dir="$XDG_CACHE_HOME/fzf-widgets"
   else
-    local dir="/tmp/fzf-widgets"
+    local dir="/tmp/fzf-widgets-$USER"
   fi
-  [[ ! -d $dir ]] && mkdir $dir
+  [[ ! -d $dir ]] && mkdir $dir && chmod 700 $dir
   export FZF_WIDGETS_CACHE="$dir/data.txt"
 }
 


### PR DESCRIPTION
## Why
Plugin work incorrect with single shared /tmp/fzf-widgets: users can view foreign fzf-widgets cache and cannot use widgets if other user created directory.

## What
- Add `$USER` to directory name
- Set 700 permissions on directory