### PR TITLE
Fix to choose image id in fzf-docker-remove-images

### DIFF
--- a/autoload/widgets/fzf-docker-remove-images
+++ b/autoload/widgets/fzf-docker-remove-images
@@ -6,6 +6,6 @@ docker image ls | \
   sed 1d | \
   selector-select $FZF_WIDGETS_OPTS[docker-remove-images] -m
 
-selector-filter "awk '{print \$1}'"
+selector-filter "awk '{print \$3}'"
 
 selector-insert


### PR DESCRIPTION
## Why

fzf-docker-remove-images not work because it choose repository name.

## What

Fix to choose image id in fzf-docker-remove-images.
