### PR TITLE
:sparkles: completion of named-directories defined with `hash -d`

### DIFF
--- a/autoload/widgets/fzf-change-named-directory
+++ b/autoload/widgets/fzf-change-named-directory
@@ -1,0 +1,8 @@
+#!/bin/zsh
+
+hash -d | sed "s/\([^=]*\)/\x1b[34;1m\1\x1b[0m/" | \
+  __fzf::widget::select $FZF_WIDGET_OPTS[change-named-directory] +m --ansi | \
+  cut -d'=' -f2 | \
+  __fzf::widget::insert -q
+
+__fzf::widget::exec


### PR DESCRIPTION
## Why
I use the `hash -d mnemonic=/some/directory` -> `cd ~mnemonic` feature of zsh a lot
## What

* Adds a widget `named-directories` that completes named directories.
![x](https://user-images.githubusercontent.com/273367/30135104-ded9cbaa-9359-11e7-98fd-38cbc36e81d8.png)

