### PR TITLE
Configurable find command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ if zplug check 'ytet5uy4/fzf-widgets'; then
   FZF_WIDGET_TMUX=1
 
   # use fd for finding directories and files
-  FZF_CHANGE_DIR_COMMAND="fd -t d"
-  FZF_INSERT_DIR_COMMAND="fd -t d"
-  FZF_INSERT_FILES_COMMAND="fd -t f"
+  FZF_CHANGE_DIR_FIND_COMMAND="fd -t d"
+  FZF_INSERT_DIR_FIND_COMMAND="fd -t d"
+  FZF_INSERT_FILE_COMMAND="fd -t f"
   FZF_EDIT_FILES_COMMAND="fd -t f"
 
   # modify history command to remove duplicates

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ if zplug check 'ytet5uy4/fzf-widgets'; then
 
   # Start fzf in a tmux pane
   FZF_WIDGET_TMUX=1
+
+  # use fd for finding directories and files
+  FZF_CHANGE_DIR_COMMAND="fd -t d"
+  FZF_INSERT_DIR_COMMAND="fd -t d"
+  FZF_INSERT_FILES_COMMAND="fd -t f"
+  FZF_EDIT_FILES_COMMAND="fd -t f"
+
+  # modify history command to remove duplicates
+  FZF_HISTORY_COMMAND="fc -l 1 | sed  's/^ *[0-9]*\*?  //g' | awk '!seen[\$0]++'"
 fi
 ```
 

--- a/autoload/widgets/fzf-change-directory
+++ b/autoload/widgets/fzf-change-directory
@@ -2,7 +2,7 @@
 
 __fzf::widget::init 'cd --' || return 1
 
-find . -mindepth 1 -type d -o -type l 2>/dev/null | \
+eval "${FZF_CHANGE_DIR_FIND_COMMAND:-"find . -mindepth 1 -type d -o -type l 2>/dev/null"}" | \
   sed 's|\./||g' | \
   __fzf::widget::select $FZF_WIDGET_OPTS[change-dir] +m | \
   __fzf::widget::insert -q

--- a/autoload/widgets/fzf-edit-files
+++ b/autoload/widgets/fzf-edit-files
@@ -2,10 +2,10 @@
 
 __fzf::widget::init "$EDITOR --" || return 1
 
-find -L . -type f -print -o -type l -print -o \
-  \( -path '*/\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune \
-  2> /dev/null | \
-  sed 's|\./||g' | \
+eval "${FZF_EDIT_FILES_COMMAND:-"find -L . -type f -print -o -type l -print -o \\
+  \\( -path '*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \\
+  2> /dev/null | \\
+  sed 's|\\./||g'"}" | \
   __fzf::widget::select $FZF_WIDGET_OPTS[edit-files] -m | \
   __fzf::widget::insert -q
 

--- a/autoload/widgets/fzf-insert-directory
+++ b/autoload/widgets/fzf-insert-directory
@@ -2,10 +2,12 @@
 
 __fzf::widget::init || return 1
 
-find -L . -type d -print -o -type l -print -o \
-  \( -path '*/\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune \
-  2> /dev/null | \
-  grep -v '^.$' | \
-  sed 's|\./||g' | \
+eval "${FZF_INSERT_DIR_FIND_COMMAND:-"find -L . \\
+  -type d -print -o -type l -print -o \\
+  \\( -path '*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) \\
+  -prune 2> /dev/null | \\
+  grep -v '^.$' | \\
+  sed 's|\\./||g'
+"}" | \
   __fzf::widget::select $FZF_WIDGET_OPTS[insert-directory] +m | \
   __fzf::widget::insert -q

--- a/autoload/widgets/fzf-insert-files
+++ b/autoload/widgets/fzf-insert-files
@@ -2,9 +2,9 @@
 
 __fzf::widget::init || return 1
 
-find -L . -type f -print -o -type l -print -o \
-  \( -path '*/\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune \
-  2> /dev/null | \
-  sed 's|\./||g' | \
+eval "${FZF_INSERT_FILE_COMMAND:-"find -L . -type f -print -o -type l -print -o \\
+  \\( -path '*/\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \\
+  2> /dev/null | \\
+  sed 's|\./||g'"}" | \
   __fzf::widget::select $FZF_WIDGET_OPTS[insert-files] -m | \
   __fzf::widget::insert -q

--- a/autoload/widgets/fzf-insert-history
+++ b/autoload/widgets/fzf-insert-history
@@ -2,8 +2,8 @@
 
 __fzf::widget::init || return 1
 
-fc -l 1 | \
+eval "${FZF_HISTORY_COMMAND:-"fc -l 1"}" | \
   __fzf::widget::select --tac --tiebreak=index \
   --bind=ctrl-r:toggle-sort $FZF_WIDGET_OPTS[insert-history] --query="$LBUFFER" +m | \
-  sed 's/ *[0-9]*  //g' | \
+  sed 's/^ *[0-9]*\*?  //g' | \
   __fzf::widget::replace


### PR DESCRIPTION
## Why

The dir and files widgets use `find` for searching, but it may be preferrable to use a different tool, e.g. [fd](https://github.com/sharkdp/fd), which is faster and can skip ignored or hidden files.

## What

* Adds options to configure the commands used for listing files, firectories or history entries.
* Examples for alternative commands added to README
* In `fzf-insert-history`, the regex now only matches at start of line, and also matches if the number is followed directly by a `*`.
* Otherwise behaviour stays the same, if the new variables are not set.