### PR TITLE
Avoid leaking $item into shell

### DIFF
--- a/autoload/libexec/__fzf::widget::insert
+++ b/autoload/libexec/__fzf::widget::insert
@@ -4,6 +4,7 @@ local -a items
 IFS=$'\n' items=(`cat`)
 
 if [[ -n $items ]]; then
+  local item
   for item in $items; do
     if [[ $1 = -q ]]; then
       # quote special characters with backslashes

--- a/autoload/libexec/__fzf::widget::replace
+++ b/autoload/libexec/__fzf::widget::replace
@@ -7,6 +7,7 @@ if [[ -n $items ]]; then
   BUFFER=''
   CURSOR=$#BUFFER
   zle redisplay
+  local item
   for item in $items; do
     if [[ $1 = -q ]]; then
       # quote special characters with backslashes


### PR DESCRIPTION
## Why

The $item variable is leaked into the shell. This is especially noticeable when using named dirs, my prompt showed `~item` as the current directory after using `fzf-change-directory`.

## What

* makes `item` in `__fzf::widget::insert` and `__fzf::widget::replace` local